### PR TITLE
improve Sapper error page

### DIFF
--- a/src/routes/_error.svelte
+++ b/src/routes/_error.svelte
@@ -1,24 +1,59 @@
 <script>
+    import { onMount } from 'svelte';
     export let status;
     export let error;
 
     const dev = process.env.NODE_ENV === 'development';
+
+    onMount(() => {
+        console.error(error);
+    });
 </script>
 
 <style>
-    h1,
-    p {
+    main {
+        display: flex;
+        flex-direction: column;
+        align-items: stretch;
+        justify-content: center;
+        max-width: 768px;
+        padding: 1em;
         margin: 0 auto;
+        min-height: 100vh;
+    }
+
+    h1,
+    h2 {
+        text-align: center;
     }
 
     h1 {
         font-size: 2.8em;
         font-weight: 700;
-        margin: 0 0 0.5em 0;
+        margin: 0 0 0.5rem 0;
     }
 
-    p {
-        margin: 1em auto;
+    .grid {
+        display: grid;
+        grid-template-columns: auto 1fr;
+        align-items: center;
+    }
+
+    .key {
+        padding-right: 1em;
+    }
+
+    .scroll {
+        overflow: scroll;
+    }
+
+    pre {
+        background: #eee;
+        border: 1px solid #ccc;
+        padding: 1em;
+        border-radius: 4px;
+        line-height: 1.2;
+        white-space: pre-line;
     }
 
     @media (min-width: 480px) {
@@ -29,13 +64,34 @@
 </style>
 
 <svelte:head>
-    <title>{status}</title>
+    <title>{status} - {error.message}</title>
 </svelte:head>
 
-<h1>{status}</h1>
+<main>
+    <h1>{status}</h1>
+    <h2>{error.message}</h2>
 
-<p>{error.message}</p>
-
-{#if dev && error.stack}
-    <pre>{error.stack}</pre>
-{/if}
+    {#if dev}
+        <h3>Debug Information</h3>
+        <div class="grid">
+            {#if error.debug}
+                {#each Object.entries(error.debug) as [key, value]}
+                    <div class="key">
+                        <strong>
+                            <code>{key}</code>
+                        </strong>
+                    </div>
+                    <pre class="scroll">
+                        {typeof value !== 'string' ? JSON.stringify(value, null, 2) : value}
+                    </pre>
+                {/each}
+            {/if}
+            <div class="key">
+                <strong>
+                    <code>stacktrace</code>
+                </strong>
+            </div>
+            <pre class="scroll">{error.stack}</pre>
+        </div>
+    {/if}
+</main>

--- a/src/routes/preview/[chartId]/_helpers.js
+++ b/src/routes/preview/[chartId]/_helpers.js
@@ -13,6 +13,15 @@ export function createAPI(fetch, headers) {
             }
             const error = new TypeError(res.statusText);
             error.status = res.status;
+            const contentType = res.headers
+                .get('content-type')
+                .split(';')
+                .shift();
+            error.debug = {
+                url: res.url,
+                'response-body':
+                    contentType === 'application/json' ? await res.json() : await res.text()
+            };
             throw error;
         }
         return response;

--- a/src/routes/preview/[chartId]/index.svelte
+++ b/src/routes/preview/[chartId]/index.svelte
@@ -32,7 +32,7 @@
             chart = publishData.chart;
             publishData.chart = undefined;
         } catch (error) {
-            return this.error(error.status, error.message);
+            return this.error(error.status, error);
         }
 
         const csv = publishData.data;
@@ -50,7 +50,7 @@
             theme = results[1];
             theme.less = '';
         } catch (error) {
-            return this.error(error.status, error.message);
+            return this.error(error.status, error);
         }
 
         vis.locale = publishData.locales;


### PR DESCRIPTION
This PR improves the output of Sappers error page. There has been a lot of confusion when things went wrong, loading a page. I hope this change clears that up with some information about requests and error stacktraces.

## Page

![Screen Shot 2020-04-08 at 15 33 41](https://user-images.githubusercontent.com/5798652/78790494-e2872700-79ae-11ea-95a2-944b8e32cd9f.png)
 
## Console

![Screenshot 2020-04-08 at 15 34 14](https://user-images.githubusercontent.com/5798652/78790516-ea46cb80-79ae-11ea-8aac-f1b17fe7eff7.png)
