### PR TITLE
fix: don't cache preview in production

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -46,7 +46,6 @@ function overrideSetHeader(req, res, next) {
     const origSetHeader = res.setHeader;
     res.setHeader = function(key, value) {
         if (key === 'Cache-Control') {
-            console.log(key, value);
             if (value === 'max-age=600') {
                 // HTML files
                 return origSetHeader.apply(this, ['Cache-Control', 'public, no-cache']);


### PR DESCRIPTION
As noticed by @davidkokkelink, Sapper caches `.html` requests with a `max-age=600` value. This is super annoying for our preview and also a little weird since these pages are by nature dynamic in Sapper.

This is the offending line:
> ```js
> res.setHeader('Cache-Control', dev ? 'no-cache' : 'max-age=600');
> ```
> - https://github.com/sveltejs/sapper/blob/master/runtime/src/server/middleware/get_page_handler.ts#L57

There is an existing issue in the Sapper repository discussing this exact problem (https://github.com/sveltejs/sapper/issues/567). There is a kind of hacky workaround provided by Nolan Lawson in the issue which I copied and adapted a little.

The issue exists for over a year, so I wouldn't hold my breath that this gets fixed in Sapper anytime soon.