### PR TITLE
Remove nomodule polyfill

### DIFF
--- a/src/template.html
+++ b/src/template.html
@@ -9,15 +9,12 @@
 
         <link rel="stylesheet" href="static_sapper/global.css" />
 
-        <!-- nomodule causes modern browsers to ignore this script -->
-        <script nomodule src="lib/polyfills/all.js"></script>
-
         <!-- Sapper generates a <style> tag containing critical CSS
 	     for the current page. CSS for the rest of the app is
 	     lazily loaded when it precaches secondary pages -->
         %sapper.styles%
 
-        <!-- This contains the contents of the <svelte:head> component, if
+        <!-- This contains the contenwelts of the <svelte:head> component, if
 	     the current page has one -->
         %sapper.head%
     </head>

--- a/src/template.html
+++ b/src/template.html
@@ -14,7 +14,7 @@
 	     lazily loaded when it precaches secondary pages -->
         %sapper.styles%
 
-        <!-- This contains the contenwelts of the <svelte:head> component, if
+        <!-- This contains the contents of the <svelte:head> component, if
 	     the current page has one -->
         %sapper.head%
     </head>


### PR DESCRIPTION
We decided against using `<script nomodule`-type browser detection for serving polyfills since it doesn't support the granularity we need, and because certain Safari versions don't play nicely with it.

Do we still need this, then? We should load the appropriate polyfill file in `chart-core/main.js`, right? 