### PR TITLE
implement graceful restart with pm2

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -128,7 +128,7 @@ async function main() {
         return next();
     };
 
-    polka()
+    const app = polka()
         .use(
             serveStatic('static'),
             serveLibraries,
@@ -148,6 +148,18 @@ async function main() {
         )
         .listen(PORT, err => {
             if (err) process.stdout.write('error', err);
+            else {
+                // graceful start and stop
+                process.send('ready');
+
+                process.on('SIGINT', async function() {
+                    console.log('received SIGINT, closing connections...');
+                    app.server.close(() => {
+                        console.log('server has stopped');
+                        process.exit(0);
+                    });
+                });
+            }
         });
 }
 


### PR DESCRIPTION
I *think* this is how `polka` is supposed to be gracefully stopped, according to https://github.com/lukeed/polka/issues/39

there might be an issue with keep-alive connections but since `pm2` also has a kill timeout to forcefully kill a cluster after x seconds I think we should be fine.
