### PR TITLE
use expr-eval chart-core

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1334,11 +1334,12 @@
       }
     },
     "@datawrapper/chart-core": {
-      "version": "github:datawrapper/chart-core#51067865ce453249c13d05cfc6f64104fa90e0e8",
-      "from": "github:datawrapper/chart-core#expr-eval",
+      "version": "8.12.1",
+      "resolved": "https://registry.npmjs.org/@datawrapper/chart-core/-/chart-core-8.12.1.tgz",
+      "integrity": "sha512-GuFtCaL2LiuHtYopkCk0n2xbwBNZekPj02T75cod8H1t4LVo0HngklOqtdQitDOBAwh7XWg8ysQ5lFdxb6Ur7Q==",
       "requires": {
         "@datawrapper/polyfills": "2.0.0-0",
-        "@datawrapper/shared": "github:datawrapper/shared#expr-eval",
+        "@datawrapper/shared": "^0.25.6",
         "core-js": "3.6.5",
         "d3-array": "~2.4.0",
         "expr-eval": "github:gka/expr-eval#patch-1",
@@ -1347,10 +1348,11 @@
       },
       "dependencies": {
         "@datawrapper/shared": {
-          "version": "github:datawrapper/shared#33def56b91673fd2c96ab612dd5540fcd310850e",
-          "from": "github:datawrapper/shared#expr-eval",
+          "version": "0.25.6",
+          "resolved": "https://registry.npmjs.org/@datawrapper/shared/-/shared-0.25.6.tgz",
+          "integrity": "sha512-NxvxCUhTKooRcD5mol+/NYFb6WBU5PZ3GKRFCvYSIUnb4F934j+tkalk2PuJNZf0A88gOEtgtorWDYpko6Gr8w==",
           "requires": {
-            "@datawrapper/chart-core": "^8.8.0",
+            "@datawrapper/chart-core": "^8.12.0",
             "chroma-js": "^2.0.3",
             "d3-array": "^1.2.4",
             "lodash-es": "^4.17.15",
@@ -1376,11 +1378,6 @@
           "version": "2.16.1",
           "resolved": "https://registry.npmjs.org/svelte/-/svelte-2.16.1.tgz",
           "integrity": "sha512-TpXdfukSkmWkMnH6PPVm7FRW8SSFcTyqBiP+6VN8rtZJ7Lp1Xbf/e3oz73eQBxF0UPZw1aAn1b91lX2XTeD3zg=="
-        },
-        "underscore": {
-          "version": "1.10.2",
-          "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.10.2.tgz",
-          "integrity": "sha512-N4P+Q/BuyuEKFJ43B9gYuOj4TQUHXX+j2FqguVOpjkssLUUrnJofCcBccJSCoeturDoZU6GorDTHSvUDlSQbTg=="
         }
       }
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1334,14 +1334,54 @@
       }
     },
     "@datawrapper/chart-core": {
-      "version": "8.11.3",
-      "resolved": "https://registry.npmjs.org/@datawrapper/chart-core/-/chart-core-8.11.3.tgz",
-      "integrity": "sha512-gIlYUZ7yZxXODlxTMgkIfmvOXP4hR7ueXwKU49OSHyGfczBmwW5mp6bp7pxn8nS9TCWkhIVxDy4Tl+gqZVIykA==",
+      "version": "github:datawrapper/chart-core#51067865ce453249c13d05cfc6f64104fa90e0e8",
+      "from": "github:datawrapper/chart-core#expr-eval",
       "requires": {
         "@datawrapper/polyfills": "2.0.0-0",
-        "@datawrapper/shared": "^0.25.3",
+        "@datawrapper/shared": "github:datawrapper/shared#expr-eval",
         "core-js": "3.6.5",
-        "fontfaceobserver": "2.1.0"
+        "d3-array": "~2.4.0",
+        "expr-eval": "github:gka/expr-eval#patch-1",
+        "fontfaceobserver": "2.1.0",
+        "underscore": "^1.10.2"
+      },
+      "dependencies": {
+        "@datawrapper/shared": {
+          "version": "github:datawrapper/shared#33def56b91673fd2c96ab612dd5540fcd310850e",
+          "from": "github:datawrapper/shared#expr-eval",
+          "requires": {
+            "@datawrapper/chart-core": "^8.8.0",
+            "chroma-js": "^2.0.3",
+            "d3-array": "^1.2.4",
+            "lodash-es": "^4.17.15",
+            "sinon": "^7.3.2",
+            "svelte": "^2.16.1",
+            "svelte-extras": "^2.0.2",
+            "underscore": "^1.9.1"
+          },
+          "dependencies": {
+            "d3-array": {
+              "version": "1.2.4",
+              "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-1.2.4.tgz",
+              "integrity": "sha512-KHW6M86R+FUPYGb3R5XiYjXPq7VzwxZ22buHhAEVG5ztoEcZZMLov530mmccaqA1GghZArjQV46fuc8kUqhhHw=="
+            }
+          }
+        },
+        "d3-array": {
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-2.4.0.tgz",
+          "integrity": "sha512-KQ41bAF2BMakf/HdKT865ALd4cgND6VcIztVQZUTt0+BH3RWy6ZYnHghVXf6NFjt2ritLr8H1T8LreAAlfiNcw=="
+        },
+        "svelte": {
+          "version": "2.16.1",
+          "resolved": "https://registry.npmjs.org/svelte/-/svelte-2.16.1.tgz",
+          "integrity": "sha512-TpXdfukSkmWkMnH6PPVm7FRW8SSFcTyqBiP+6VN8rtZJ7Lp1Xbf/e3oz73eQBxF0UPZw1aAn1b91lX2XTeD3zg=="
+        },
+        "underscore": {
+          "version": "1.10.2",
+          "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.10.2.tgz",
+          "integrity": "sha512-N4P+Q/BuyuEKFJ43B9gYuOj4TQUHXX+j2FqguVOpjkssLUUrnJofCcBccJSCoeturDoZU6GorDTHSvUDlSQbTg=="
+        }
       }
     },
     "@datawrapper/locales": {
@@ -2808,6 +2848,10 @@
           }
         }
       }
+    },
+    "expr-eval": {
+      "version": "github:gka/expr-eval#cc1a07ab34e480c8dd6b5575fa20ca9f929ab558",
+      "from": "github:gka/expr-eval#patch-1"
     },
     "external-editor": {
       "version": "3.1.0",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
         "prepare": "npm run build"
     },
     "dependencies": {
-        "@datawrapper/chart-core": "github:datawrapper/chart-core#expr-eval",
+        "@datawrapper/chart-core": "^8.12.1",
         "@datawrapper/locales": "1.0.0",
         "@datawrapper/orm": "3.13.0",
         "@datawrapper/shared": "^0.25.4",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
         "prepare": "npm run build"
     },
     "dependencies": {
-        "@datawrapper/chart-core": "^8.11.3",
+        "@datawrapper/chart-core": "github:datawrapper/chart-core#expr-eval",
         "@datawrapper/locales": "1.0.0",
         "@datawrapper/orm": "3.13.0",
         "@datawrapper/shared": "^0.25.4",


### PR DESCRIPTION
temporary PR for deploying expr-eval on staging. The `github:datawrapper/chart-core#expr-eval` dependency will be changed.