### PR TITLE
Add oAuth2 functionality

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -37,6 +37,13 @@
                 "svelte-extras": "^2.0.2",
                 "svelte2": "npm:svelte@^2.16.1",
                 "underscore": "^1.11.0"
+            },
+            "dependencies": {
+                "svelte2": {
+                    "version": "npm:svelte@2.16.1",
+                    "resolved": "https://registry.npmjs.org/svelte/-/svelte-2.16.1.tgz",
+                    "integrity": "sha512-TpXdfukSkmWkMnH6PPVm7FRW8SSFcTyqBiP+6VN8rtZJ7Lp1Xbf/e3oz73eQBxF0UPZw1aAn1b91lX2XTeD3zg=="
+                }
             }
         },
         "@datawrapper/expr-eval": {
@@ -135,6 +142,19 @@
             "integrity": "sha512-ngu0tSEmrezoiIaNGG6rRvKOUkUuDdf4XTPnONHGYfSGRmDqPZX5oJL6HAdKTo1UQHECbdB4OzhWrfgVppjHUw==",
             "requires": {
                 "@hapi/hoek": "9.x.x"
+            }
+        },
+        "@hapi/bell": {
+            "version": "12.1.1",
+            "resolved": "https://registry.npmjs.org/@hapi/bell/-/bell-12.1.1.tgz",
+            "integrity": "sha512-KD7Kx5+2J9bGA2bTgLS2Vkf8TJ0shsjsdcu+ccTPciGpvl8rzbbZdxEydtLa87MSxsISag8JszXlyPRt58VpmQ==",
+            "requires": {
+                "@hapi/boom": "9.x.x",
+                "@hapi/bounce": "2.x.x",
+                "@hapi/cryptiles": "^5.1.0",
+                "@hapi/hoek": "9.x.x",
+                "@hapi/wreck": "17.x.x",
+                "joi": "17.x.x"
             }
         },
         "@hapi/boom": {
@@ -1057,6 +1077,18 @@
             "resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.15.0.tgz",
             "integrity": "sha1-o/Iiqarp+Wb10nx5ZRDigJF2Qhc="
         },
+        "joi": {
+            "version": "17.2.1",
+            "resolved": "https://registry.npmjs.org/joi/-/joi-17.2.1.tgz",
+            "integrity": "sha512-YT3/4Ln+5YRpacdmfEfrrKh50/kkgX3LgBltjqnlMPIYiZ4hxXZuVJcxmsvxsdeHg9soZfE3qXxHC2tMpCCBOA==",
+            "requires": {
+                "@hapi/address": "^4.1.0",
+                "@hapi/formula": "^2.0.0",
+                "@hapi/hoek": "^9.0.0",
+                "@hapi/pinpoint": "^2.0.0",
+                "@hapi/topo": "^5.0.0"
+            }
+        },
         "joycon": {
             "version": "2.2.5",
             "resolved": "https://registry.npmjs.org/joycon/-/joycon-2.2.5.tgz",
@@ -1695,11 +1727,6 @@
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/svelte-extras/-/svelte-extras-2.0.2.tgz",
             "integrity": "sha512-yoxNehbDxGEHxJBTWq2RpIPDTHlNNy6eGR7RPSK7qsh8hoyOXbji8uF//l4+I/l2fLP+E8pQTJYrduPXrW3wsw=="
-        },
-        "svelte2": {
-            "version": "npm:svelte@2.16.1",
-            "resolved": "https://registry.npmjs.org/svelte/-/svelte-2.16.1.tgz",
-            "integrity": "sha512-TpXdfukSkmWkMnH6PPVm7FRW8SSFcTyqBiP+6VN8rtZJ7Lp1Xbf/e3oz73eQBxF0UPZw1aAn1b91lX2XTeD3zg=="
         },
         "to-fast-properties": {
             "version": "2.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,13 +37,6 @@
                 "svelte-extras": "^2.0.2",
                 "svelte2": "npm:svelte@^2.16.1",
                 "underscore": "^1.11.0"
-            },
-            "dependencies": {
-                "svelte2": {
-                    "version": "npm:svelte@2.16.1",
-                    "resolved": "https://registry.npmjs.org/svelte/-/svelte-2.16.1.tgz",
-                    "integrity": "sha512-TpXdfukSkmWkMnH6PPVm7FRW8SSFcTyqBiP+6VN8rtZJ7Lp1Xbf/e3oz73eQBxF0UPZw1aAn1b91lX2XTeD3zg=="
-                }
             }
         },
         "@datawrapper/expr-eval": {
@@ -1727,6 +1720,11 @@
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/svelte-extras/-/svelte-extras-2.0.2.tgz",
             "integrity": "sha512-yoxNehbDxGEHxJBTWq2RpIPDTHlNNy6eGR7RPSK7qsh8hoyOXbji8uF//l4+I/l2fLP+E8pQTJYrduPXrW3wsw=="
+        },
+        "svelte2": {
+            "version": "npm:svelte@2.16.1",
+            "resolved": "https://registry.npmjs.org/svelte/-/svelte-2.16.1.tgz",
+            "integrity": "sha512-TpXdfukSkmWkMnH6PPVm7FRW8SSFcTyqBiP+6VN8rtZJ7Lp1Xbf/e3oz73eQBxF0UPZw1aAn1b91lX2XTeD3zg=="
         },
         "to-fast-properties": {
             "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
         "@datawrapper/locales": "^1.0.3",
         "@datawrapper/orm": "^3.18.5",
         "@datawrapper/service-utils": "^0.1.2",
+        "@hapi/bell": "^12.1.1",
         "@hapi/hapi": "19.1.1",
         "@hapi/inert": "^6.0.2",
         "@hapi/vision": "^6.0.1",

--- a/src/auth/dw-auth.js
+++ b/src/auth/dw-auth.js
@@ -1,7 +1,7 @@
 const Boom = require('@hapi/boom');
 const Bell = require('@hapi/bell');
 const get = require('lodash/get');
-const { cookieValidation, adminValidation, getUser, createCookieAuthScheme } = require('@datawrapper/service-utils/auth')(require('@datawrapper/orm/models'));
+const { cookieValidation, adminValidation, generateToken, createCookieAuthScheme } = require('@datawrapper/service-utils/auth')(require('@datawrapper/orm/models'));
 const cookieAuthScheme = createCookieAuthScheme(true);
 
 const DWAuth = {
@@ -37,7 +37,7 @@ const DWAuth = {
 
             server.auth.strategy(provider, 'bell', {
                 provider: provider,
-                password: 'cookie_encryption_password_secure',
+                password: generateToken(),
                 clientId: p.id,
                 clientSecret: p.secret,
 

--- a/src/auth/dw-auth.js
+++ b/src/auth/dw-auth.js
@@ -1,7 +1,7 @@
 const Boom = require('@hapi/boom');
 const Bell = require('@hapi/bell');
 const get = require('lodash/get');
-const { User, Session } = require('@datawrapper/orm/models');
+const { User } = require('@datawrapper/orm/models');
 const { cookieValidation, adminValidation, getUser, createCookieAuthScheme } = require('@datawrapper/service-utils/auth')(require('@datawrapper/orm/models'));
 const cookieAuthScheme = createCookieAuthScheme(true);
 
@@ -41,32 +41,11 @@ const DWAuth = {
                 password: 'cookie_encryption_password_secure',
                 clientId: p.id,
                 clientSecret: p.secret,
-                isSecure: server.methods.config('frontend.https')
-            });
 
-            server.route({
-                method: ['GET', 'POST'],    // Must handle both GET and POST
-                path: `/oauth/${provider}`,             // The callback endpoint registered with the provider
-                options: {
-                    auth: {
-                        mode: 'try',
-                        strategy: provider
-                    },
-                    handler: function (request, h) {
-                        if (!request.auth.isAuthenticated) {
-                            return `Authentication failed due to: ${request.auth.error.message}`;
-                        }
-
-                        console.log(request.auth.credentials);
-
-                        // Perform any account lookup or registration, setup local session,
-                        // and redirect to the application. The third-party credentials are
-                        // stored in request.auth.credentials. Any query parameters from
-                        // the initial request are passed back via request.auth.credentials.query.
-
-                        return h.redirect('/home');
-                    }
-                }
+                /* this combination of settings is necessary because the node process
+                 * speaks HTTP internally, but externally HTTPS through nginx */
+                isSecure: false,
+                forceHttps: true
             });
         }
     }

--- a/src/auth/dw-auth.js
+++ b/src/auth/dw-auth.js
@@ -1,4 +1,5 @@
 const Boom = require('@hapi/boom');
+const Bell = require('@hapi/bell');
 const get = require('lodash/get');
 const { User, Session } = require('@datawrapper/orm/models');
 const { cookieValidation, adminValidation, getUser, createCookieAuthScheme } = require('@datawrapper/service-utils/auth')(require('@datawrapper/orm/models'));
@@ -8,6 +9,8 @@ const DWAuth = {
     name: 'dw-auth',
     version: '1.0.0',
     register: async (server, options) => {
+        const oauth = server.methods.config('oauth');
+
         function isAdmin(request, { throwError = false } = {}) {
             const check = get(request, ['auth', 'artifacts', 'role'], '') === 'admin';
 
@@ -20,6 +23,7 @@ const DWAuth = {
 
         server.method('isAdmin', isAdmin);
 
+        await server.register(Bell);
         server.auth.scheme('cookie-auth', cookieAuthScheme);
         server.auth.scheme('dw-auth', dwAuth);
 
@@ -28,6 +32,43 @@ const DWAuth = {
         server.auth.strategy('simple', 'dw-auth');
 
         server.auth.default('simple');
+
+        for (var provider in oauth) {
+            const p = oauth[provider];
+
+            server.auth.strategy(provider, 'bell', {
+                provider: provider,
+                password: 'cookie_encryption_password_secure',
+                clientId: p.id,
+                clientSecret: p.secret,
+                isSecure: server.methods.config('frontend.https')
+            });
+
+            server.route({
+                method: ['GET', 'POST'],    // Must handle both GET and POST
+                path: `/oauth/${provider}`,             // The callback endpoint registered with the provider
+                options: {
+                    auth: {
+                        mode: 'try',
+                        strategy: provider
+                    },
+                    handler: function (request, h) {
+                        if (!request.auth.isAuthenticated) {
+                            return `Authentication failed due to: ${request.auth.error.message}`;
+                        }
+
+                        console.log(request.auth.credentials);
+
+                        // Perform any account lookup or registration, setup local session,
+                        // and redirect to the application. The third-party credentials are
+                        // stored in request.auth.credentials. Any query parameters from
+                        // the initial request are passed back via request.auth.credentials.query.
+
+                        return h.redirect('/home');
+                    }
+                }
+            });
+        }
     }
 };
 

--- a/src/auth/dw-auth.js
+++ b/src/auth/dw-auth.js
@@ -1,7 +1,6 @@
 const Boom = require('@hapi/boom');
 const Bell = require('@hapi/bell');
 const get = require('lodash/get');
-const { User } = require('@datawrapper/orm/models');
 const { cookieValidation, adminValidation, getUser, createCookieAuthScheme } = require('@datawrapper/service-utils/auth')(require('@datawrapper/orm/models'));
 const cookieAuthScheme = createCookieAuthScheme(true);
 

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -2,6 +2,12 @@ module.exports = {
     name: 'routes',
     version: '1.0.0',
     register: async (server, options) => {
+        await server.register(require('./signin'), {
+            routes: {
+                prefix: '/signin'
+            }
+        });
+
         await server.register(require('./preview'), {
             routes: {
                 prefix: '/preview'

--- a/src/routes/signin.js
+++ b/src/routes/signin.js
@@ -22,7 +22,9 @@ module.exports = {
                             throw Boom.unauthorized();
                         };
 
+                        const { config, comparePassword } = request.server.methods;
                         const { profile } = request.auth.credentials;
+                        const api = config('api');
 
                         const oAuthSignin = `${provider}::${profile.id}`;
                         const name = profile.displayName;
@@ -70,8 +72,8 @@ module.exports = {
                             });
                         }
 
-                        const session = await login(user, request.auth.credentials, true);
-                        await request.server.methods.logAction(userId, `login/${provider}`);
+                        const session = await login(user.id, request.auth.credentials, true);
+                        await request.server.methods.logAction(user.id, `login/${provider}`);
 
                         return h
                             .response({

--- a/src/routes/signin.js
+++ b/src/routes/signin.js
@@ -63,7 +63,7 @@ module.exports = {
                             // create new user
 
                             user = await User.create({
-                                role: 'pending',
+                                role: 'editor',
                                 name,
                                 email,
                                 oauth_signin: oAuthSignin

--- a/src/routes/signin.js
+++ b/src/routes/signin.js
@@ -10,7 +10,7 @@ module.exports = {
         for (var provider in oauth) {
             server.route({
                 method: ['GET', 'POST'],
-                path: `/signin/${provider}`,
+                path: `/${provider}`,
                 options: {
                     auth: {
                         mode: 'try',
@@ -22,6 +22,8 @@ module.exports = {
                         };
 
                         const { profile } = request.auth.credentials;
+
+                        request.logger().info(profile);
 
                         const oAuthSignin = `${provider}::${profile.id}`;
                         const name = profile.displayName;

--- a/src/routes/signin.js
+++ b/src/routes/signin.js
@@ -16,7 +16,7 @@ module.exports = {
                         mode: 'try',
                         strategy: provider
                     },
-                    handler: function (request, h) {
+                    handler: async function (request, h) {
                         if (!request.auth.isAuthenticated) {
                             throw Boom.unauthorized();
                         };

--- a/src/routes/signin.js
+++ b/src/routes/signin.js
@@ -1,4 +1,4 @@
-const Boom = require('@hapi/boom')
+const Boom = require('@hapi/boom');
 const { User } = require('@datawrapper/orm/models');
 const { login } = require('@datawrapper/service-utils/auth')(require('@datawrapper/orm/models'));
 
@@ -6,7 +6,7 @@ module.exports = {
     name: 'routes/signin',
     version: '1.0.0',
     register: async (server, options) => {
-        const oauth = server.methods.config('oauth');
+        const oauth = server.methods.config('general').oauth;
 
         for (var provider in oauth) {
             server.route({
@@ -17,10 +17,10 @@ module.exports = {
                         mode: 'try',
                         strategy: provider
                     },
-                    handler: async function (request, h) {
+                    handler: async function(request, h) {
                         if (!request.auth.isAuthenticated) {
                             throw Boom.unauthorized();
-                        };
+                        }
 
                         const { config, comparePassword } = request.server.methods;
                         const { profile } = request.auth.credentials;
@@ -79,7 +79,8 @@ module.exports = {
                             .response({
                                 [api.sessionID]: session.id
                             })
-                            .state(api.sessionID, session.id, getStateOpts(request.server, 90)).redirect('/');
+                            .state(api.sessionID, session.id, getStateOpts(request.server, 90))
+                            .redirect('/');
                     }
                 }
             });

--- a/src/routes/signin.js
+++ b/src/routes/signin.js
@@ -1,0 +1,43 @@
+const Boom = require('@hapi/boom')
+const { User } = require('@datawrapper/orm/models');
+
+module.exports = {
+    name: 'routes/signin',
+    version: '1.0.0',
+    register: async (server, options) => {
+        const oauth = server.methods.config('oauth');
+
+        for (var provider in oauth) {
+            server.route({
+                method: ['GET', 'POST'],
+                path: `/signin/${provider}`,
+                options: {
+                    auth: {
+                        mode: 'try',
+                        strategy: provider
+                    },
+                    handler: function (request, h) {
+                        if (!request.auth.isAuthenticated) {
+                            throw Boom.unauthorized();
+                        };
+
+                        const { profile } = request.auth.credentials;
+
+                        const oAuthSignin = `${provider}::${profile.id}`;
+                        const name = profile.displayName;
+
+                        const user = await User.find({ where: { oauth_signin: oAuthSignin } });
+
+                        if (user) {
+                            // login user
+                        } else {
+                            // create user
+                        }
+
+                        return h.redirect('/');
+                    }
+                }
+            });
+        }
+    }
+};


### PR DESCRIPTION
This PR adds the third-party login functionality to Datawrapper's frontend service. Some architectural decisions:

- the code uses the [`@hapi/bell` plugin](https://github.com/hapijs/bell) to handle the oAuth2 process.
- it's entirely **provider-agnostic**, and fetches its available providers from the `config`:
```js
oauth: {
    twitter: {
        id: "abc",
        secret: "xyz"
    },
    google: {
        id: "def",
        secret: "uvw"
    },
    // ...
}
```
- the `frontend` registers the auth strategy and the `/signin/:provider` endpoint. once that endpoint was called, a regular user session is used so no changes are needed on other services.

---

I briefly tested the oAuth2-flow on production over the weekend (with Github, Google and twitter) and things worked as expected (difficult to impossible to do locally due to the `redirect_uri`s, etc.)

### Launch checklist
- [x] Change the `redirect_uri` in the twitter app to use `https`