### PR TITLE
Add chart creation endpoint

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -37,6 +37,13 @@
                 "svelte-extras": "^2.0.2",
                 "svelte2": "npm:svelte@^2.16.1",
                 "underscore": "^1.11.0"
+            },
+            "dependencies": {
+                "svelte2": {
+                    "version": "npm:svelte@2.16.1",
+                    "resolved": "https://registry.npmjs.org/svelte/-/svelte-2.16.1.tgz",
+                    "integrity": "sha512-TpXdfukSkmWkMnH6PPVm7FRW8SSFcTyqBiP+6VN8rtZJ7Lp1Xbf/e3oz73eQBxF0UPZw1aAn1b91lX2XTeD3zg=="
+                }
             }
         },
         "@datawrapper/expr-eval": {
@@ -1843,11 +1850,6 @@
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/svelte-extras/-/svelte-extras-2.0.2.tgz",
             "integrity": "sha512-yoxNehbDxGEHxJBTWq2RpIPDTHlNNy6eGR7RPSK7qsh8hoyOXbji8uF//l4+I/l2fLP+E8pQTJYrduPXrW3wsw=="
-        },
-        "svelte2": {
-            "version": "npm:svelte@2.16.1",
-            "resolved": "https://registry.npmjs.org/svelte/-/svelte-2.16.1.tgz",
-            "integrity": "sha512-TpXdfukSkmWkMnH6PPVm7FRW8SSFcTyqBiP+6VN8rtZJ7Lp1Xbf/e3oz73eQBxF0UPZw1aAn1b91lX2XTeD3zg=="
         },
         "to-fast-properties": {
             "version": "2.0.0",

--- a/src/routes/create/index.js
+++ b/src/routes/create/index.js
@@ -1,24 +1,82 @@
-const createChart = require('@datawrapper/service-utils/createChart');
 const Joi = require('@hapi/joi');
+const createChart = require('@datawrapper/service-utils/createChart');
+const { includes } = require('lodash');
 
 module.exports = {
-    name: 'routes/preview',
+    name: 'routes/create',
     version: '1.0.0',
-    register: async (server, options) => {
+    register: async (server) => {
         server.route({
             method: 'GET',
             options: {
                 validate: {
                     params: Joi.object({
-                        type: Joi.string()
+                        workflow: Joi.string()
                             .required()
                             .valid('chart', 'map', 'table')
+                    }),
+                    query: Joi.object({
+                        type: Joi.string()
+                            .valid(Array.from(server.app.visualizations.keys()))
+                            .optional(),
+                        folder: Joi.string()
+                            .optional(),
+                        basemap: Joi.string()
+                            .optional(),
+                        theme: Joi.string()
+                            .optional(),
+                        template: Joi.string()
+                            .optional()
                     })
                 }
             },
-            path: '/{type}',
+            path: '/{workflow}',
             handler: async (request, h) => {
+                const { auth, query, params } = request;
+                const user = auth.artifacts;
 
+                const chart = await createChart({
+                    server,
+                    user,
+                    session: auth.credentials.session,
+                    payload: {
+                        type: query.type,
+                        theme: query.theme,
+                        metadata: query.basemap ? { visualize: { basemap: query.basemap } }
+                    }
+                });
+
+                if (query.folder) {
+                    const folder = await Folder.findByPk(query.folder);
+
+                    if (await folder.isWritableBy(user)) {
+                        chart.in_folder = query.folder;
+                    }
+                }
+
+                if (query.template) {
+                    const chartTemplate = await Chart.findByPk(query.template);
+
+                    if (chartTemplate && chartTemplate.organization_id) {
+                        const team = await Team.findByPk(chart.organization_id);
+
+                        if (team.settings['chart-templates']) {
+                            const publicChart = await PublicChart.findByPk(chartTemplate.id);
+
+                            if (publicChart) {
+                                // copy properties from publicchart
+                            } else {
+                                // copy properties from chart
+                            }
+
+                            await request.server.methods.logAction(user.id, `chart/template`, chartTemplate.id);
+                        }
+                    }
+                }
+
+
+                await chart.save();
+                h.redirect(`/${params.workflow}/${chart.id}/edit`);
             }
         });
     }

--- a/src/routes/create/index.js
+++ b/src/routes/create/index.js
@@ -1,6 +1,6 @@
 const Joi = require('@hapi/joi');
 const createChart = require('@datawrapper/service-utils/createChart');
-const { includes } = require('lodash');
+const { Chart, Folder, Team } = require('@datawrapper/orm');
 
 module.exports = {
     name: 'routes/create',

--- a/src/routes/create/index.js
+++ b/src/routes/create/index.js
@@ -1,0 +1,25 @@
+const createChart = require('@datawrapper/service-utils/createChart');
+const Joi = require('@hapi/joi');
+
+module.exports = {
+    name: 'routes/preview',
+    version: '1.0.0',
+    register: async (server, options) => {
+        server.route({
+            method: 'GET',
+            options: {
+                validate: {
+                    params: Joi.object({
+                        type: Joi.string()
+                            .required()
+                            .valid('chart', 'map', 'table')
+                    })
+                }
+            },
+            path: '/{type}',
+            handler: async (request, h) => {
+
+            }
+        });
+    }
+};

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -15,6 +15,12 @@ module.exports = {
             }
         });
 
+        await server.register(require('./create/index.js'), {
+            routes: {
+                prefix: '/create'
+            }
+        });
+
         await server.register(require('./lib'), {
             routes: {
                 prefix: '/lib'


### PR DESCRIPTION
Adds `/create/(chart|map|table)` endpoint for the creation of new visualizations

### Dependencies
- https://github.com/datawrapper/service-utils/pull/5
- https://github.com/datawrapper/orm/pull/46

### Open questions
- How backwards-compatible do we want to be with the current endpoint? In the [distant past](https://blog.datawrapper.de/2013/09/2013-09-03-feeding-data-into-datawrapper/), the `create` endpoint could be used by third-party website to pass in chart data in the post body. This isn't supported anymore (due to cookie restrictions & CSRF protection), so I would suggest removing the unused functionality.

### Remaining tasks
- [ ] Implement copying of chart properties and data from `chart-template`