### PR TITLE
Allow transparent preview

### DIFF
--- a/src/routes/preview/index.js
+++ b/src/routes/preview/index.js
@@ -57,7 +57,7 @@ module.exports = {
                     const results = await Promise.all([
                         getVis(api, chart.type),
                         getTheme(api, themeName),
-                        getStyles(api, chart.type, themeName)
+                        getStyles(api, chart.type, themeName, !!request.query.transparent)
                     ]);
 
                     vis = results[0];

--- a/src/routes/preview/utils.js
+++ b/src/routes/preview/utils.js
@@ -85,13 +85,13 @@ module.exports = {
         });
 
         return {
-            async getStyles(api, visId, themeId) {
-                if (get(config, 'general.cache.styles')) {
+            async getStyles(api, visId, themeId, transparent) {
+                if (get(config, 'general.cache.styles') && !transparent) {
                     const cachedCSS = await styleCache.get(`${themeId}__${visId}`);
                     if (cachedCSS) return cachedCSS;
                 }
 
-                return api(`/visualizations/${visId}/styles.css?theme=${themeId}`, {
+                return api(`/visualizations/${visId}/styles.css?theme=${themeId}${transparent ? '&transparent=true' : ''}`, {
                     json: false
                 });
             },


### PR DESCRIPTION
Add `transparent=true` query parameter to enforce a preview with transparent background