### PR TITLE
Fix robot_500 font URL

### DIFF
--- a/src/styles/fonts/roboto.scss
+++ b/src/styles/fonts/roboto.scss
@@ -1,4 +1,3 @@
-
 /* cyrillic-ext */
 @font-face {
   font-family: 'Roboto';
@@ -224,11 +223,11 @@
   unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
 }
 @font-face {
-    font-family: 'Roboto';
-    font-style: normal;
-    font-weight: 500;
-    src: local('Roboto Medium'), local('Roboto-Medium'), url('/fonts/roboto/roboto_500.woff2') format('woff2'), url('/fonts/roboto/roboto_500.woff') format('woff'), url('/fonts/roboto/roboto_500.eot?#iefix') format('embedded-opentype'), url('/fonts/roboto/roboto_500.svg#Roboto') format('svg'), url('/fonts/roboto/roboto_500.ttf') format('truetype');
-    unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
+  font-family: 'Roboto';
+  font-style: normal;
+  font-weight: 500;
+  src: local('Roboto Medium'), local('Roboto-Medium'), url('fonts/roboto/roboto_500.woff2') format('woff2'), url('fonts/roboto/roboto_500.woff') format('woff'), url('fonts/roboto/roboto_500.eot?#iefix') format('embedded-opentype'), url('fonts/roboto/roboto_500.svg#Roboto') format('svg'), url('fonts/roboto/roboto_500.ttf') format('truetype');
+  unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
 }
 /* cyrillic-ext */
 @font-face {

--- a/static/datawrapper.css
+++ b/static/datawrapper.css
@@ -226,7 +226,7 @@
   font-family: 'Roboto';
   font-style: normal;
   font-weight: 500;
-  src: local("Roboto Medium"), local("Roboto-Medium"), url("/fonts/roboto/roboto_500.woff2") format("woff2"), url("/fonts/roboto/roboto_500.woff") format("woff"), url("/fonts/roboto/roboto_500.eot?#iefix") format("embedded-opentype"), url("/fonts/roboto/roboto_500.svg#Roboto") format("svg"), url("/fonts/roboto/roboto_500.ttf") format("truetype");
+  src: local("Roboto Medium"), local("Roboto-Medium"), url("fonts/roboto/roboto_500.woff2") format("woff2"), url("fonts/roboto/roboto_500.woff") format("woff"), url("fonts/roboto/roboto_500.eot?#iefix") format("embedded-opentype"), url("fonts/roboto/roboto_500.svg#Roboto") format("svg"), url("fonts/roboto/roboto_500.ttf") format("truetype");
   unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD; }
 
 /* cyrillic-ext */


### PR DESCRIPTION
Change the URL form absolute to relative, because all other fonts have relative URL.

Not tested.

See also https://github.com/datawrapper/datawrapper/pull/461