### PR TITLE
preview: Set HTML LANG attribute

### DIFF
--- a/src/routes/preview/index.js
+++ b/src/routes/preview/index.js
@@ -74,9 +74,7 @@ module.exports = {
 
                 const chartLocale = props.chart.language || 'en-US';
 
-                const dependencies = [
-                    'dw-2.0.min.js',
-                ];
+                const dependencies = ['dw-2.0.min.js'];
 
                 const team = await Team.findByPk(props.chart.organizationId);
                 props = Object.assign(props, {
@@ -86,7 +84,7 @@ module.exports = {
                     locales: {
                         dayjs: loadVendorLocale(locales, 'dayjs', chartLocale, team),
                         numeral: loadVendorLocale(locales, 'numeral', chartLocale, team)
-                    },
+                    }
                 });
 
                 const css = props.styles;
@@ -101,7 +99,7 @@ module.exports = {
                 props.assets = assets;
 
                 const libraries = props.visualization.libraries.map(lib => lib.uri);
-              
+
                 props.frontendDomain = config.frontend.domain;
 
                 const { html, head } = chartCore.svelte.render(props);
@@ -114,6 +112,7 @@ module.exports = {
                     }),
                     CHART_HTML: html,
                     CHART_HEAD: head,
+                    CHART_LOCALE: chartLocale,
                     VIS_SCRIPT: `${apiBase}/visualizations/${props.visualization.id}/script.js`,
                     MAIN_SCRIPT: '/lib/chart-core/main.js',
                     POLYFILL_SCRIPT: '/lib/chart-core/load-polyfills.js',

--- a/src/views/preview.pug
+++ b/src/views/preview.pug
@@ -1,5 +1,5 @@
 doctype html
-html(lang="en")
+html(lang=CHART_LOCALE)
   head
     meta(charset="UTF-8")
     meta(name="viewport", content="width=device-width, initial-scale=1.0")


### PR DESCRIPTION
#### Steps to reproduce

1. Export PNG of https://app.datawrapper.de/chart/WI0Y6/visualize#design
2. See that the Japanese kanji characters are rendered as Chinese characters.
3. In Firefox, the characters are wrong also in the chart preview.

result:
![WI0Y6--chinese](https://user-images.githubusercontent.com/58857807/123114275-8091d080-d43f-11eb-85f7-64ae9d9633e3.png)

expected:
![E4WPG--japanese](https://user-images.githubusercontent.com/58857807/123114363-87204800-d43f-11eb-8d66-fafd43f14c4b.png)

Issue: https://www.notion.so/datawrapper/Issue-with-japanese-fonts-in-PNGs-seems-to-be-back-c1a5143b78834c8e926c2e6b0895051d

#### Changes

Set the correct HTML LANG attribute of the chart preview document. This helps the browser (both customer's browser and the headless browser inside our render-client) choose the right font -- which affects whether Chinese or Japanese characters are rendered.

Add three chart tests:
- https://github.com/datawrapper/plugin-d3-lines/blob/master/tests/charts/cjk-text-chinese.json
- https://github.com/datawrapper/plugin-d3-lines/blob/master/tests/charts/cjk-text-english.json
- https://github.com/datawrapper/plugin-d3-lines/blob/master/tests/charts/cjk-text-japanese.json

#### Testing

1. Copy https://app.datawrapper.de/chart/WI0Y6/visualize#design to local.
2. See that the PNG export shows Chinese characters.
3. Change chart language to Japanase.
4. See that the PNG export shows Japanese characters.