### PR TITLE
Add logo query parameter to preview

### DIFF
--- a/src/routes/preview/index.js
+++ b/src/routes/preview/index.js
@@ -41,7 +41,7 @@ module.exports = {
                         svgonly: fakeBoolean,
                         map2svg: fakeBoolean,
                         transparent: fakeBoolean,
-                        logo: Joi.string().optional().valid('forceOn', 'forceOff', 'auto')
+                        logo: fakeBoolean
                     })
                 }
             },

--- a/src/routes/preview/index.js
+++ b/src/routes/preview/index.js
@@ -41,7 +41,7 @@ module.exports = {
                         svgonly: fakeBoolean,
                         map2svg: fakeBoolean,
                         transparent: fakeBoolean,
-                        logo: fakeBoolean
+                        logo: Joi.string().optional().valid('auto', 'on', 'off').default('auto')
                     })
                 }
             },

--- a/src/routes/preview/index.js
+++ b/src/routes/preview/index.js
@@ -40,7 +40,8 @@ module.exports = {
                         fitheight: fakeBoolean,
                         svgonly: fakeBoolean,
                         map2svg: fakeBoolean,
-                        transparent: fakeBoolean
+                        transparent: fakeBoolean,
+                        logo: Joi.string().optional().valid('forceOn', 'forceOff', 'auto')
                     })
                 }
             },
@@ -60,7 +61,8 @@ module.exports = {
                     published: request.query.published,
                     ott: request.query.ott,
                     theme: request.query.theme,
-                    transparent: request.query.transparent
+                    transparent: request.query.transparent,
+                    logo: request.query.logo
                 })
                     .filter(([, value]) => Boolean(value))
                     .map(([key, value]) => `${key}=${value}`)

--- a/src/views/preview.pug
+++ b/src/views/preview.pug
@@ -15,10 +15,9 @@ html(lang=CHART_LOCALE)
       window.__DW_SVELTE_PROPS__ = JSON.parse(!{__DW_SVELTE_PROPS__});
       window.__DW_SVELTE_PROPS__.isStylePlain = /[?&]plain=1/.test(window.location.search);
       window.__DW_SVELTE_PROPS__.isStyleStatic = /[?&]static=1/.test(window.location.search);
-      if (/[?&]logo=[0|1]/.test(window.location.search)) {
-        window.__DW_SVELTE_PROPS__.forceLogoSetting = !!Number((window.location.search).match(/[?&]logo=(0|1)/)[1]);
+      if (/[?&]logo=(auto|on|off)/.test(window.location.search)) {
+        window.__DW_SVELTE_PROPS__.forceLogo = (window.location.search).match(/[?&]logo=(auto|on|off)/)[1];
       }
-
     each src in DEPS
       script(src=src)
 

--- a/src/views/preview.pug
+++ b/src/views/preview.pug
@@ -15,9 +15,9 @@ html(lang=CHART_LOCALE)
       window.__DW_SVELTE_PROPS__ = JSON.parse(!{__DW_SVELTE_PROPS__});
       window.__DW_SVELTE_PROPS__.isStylePlain = /[?&]plain=1/.test(window.location.search);
       window.__DW_SVELTE_PROPS__.isStyleStatic = /[?&]static=1/.test(window.location.search);
-      window.__DW_SVELTE_PROPS__.logoSetting = (window.location.search).match(/[?&]logo=(forceOn|forceOff|auto)/)
-        ? (window.location.search).match(/[?&]logo=(forceOn|forceOff|auto)/)[1]
-        : 'auto';
+      if (/[?&]logo=[0|1]/.test(window.location.search)) {
+        window.__DW_SVELTE_PROPS__.forceLogoSetting = !!Number((window.location.search).match(/[?&]logo=(0|1)/)[1]);
+      }
 
     each src in DEPS
       script(src=src)

--- a/src/views/preview.pug
+++ b/src/views/preview.pug
@@ -15,6 +15,9 @@ html(lang=CHART_LOCALE)
       window.__DW_SVELTE_PROPS__ = JSON.parse(!{__DW_SVELTE_PROPS__});
       window.__DW_SVELTE_PROPS__.isStylePlain = /[?&]plain=1/.test(window.location.search);
       window.__DW_SVELTE_PROPS__.isStyleStatic = /[?&]static=1/.test(window.location.search);
+      window.__DW_SVELTE_PROPS__.logoSetting = (window.location.search).match(/[?&]logo=(forceOn|forceOff|auto)/)
+        ? (window.location.search).match(/[?&]logo=(forceOn|forceOff|auto)/)[1]
+        : 'auto';
 
     each src in DEPS
       script(src=src)


### PR DESCRIPTION
So that we can make the logo an export option. More details in [ticket](https://www.notion.so/datawrapper/Allow-users-to-configure-logo-to-be-shown-hidden-in-exported-PNG-5a961a96674047c4a19da1415685aa29).

Also save to `window.__DW_SVELTE_PROPS__.forceLogoSetting`, if present (so `undefined` = don't mess with the logo).

- Not sure we need to save it to the window, I'm not clear on what the pattern is regarding which query parameters we save to the window and which we just fetch where we need them
- Not sure if treating `undefined` as `auto` is a good way to go about things