### PR TITLE
add nodemon.json for easier editing of watch/ignore patterns

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ config.js
 src/views/plugins/*
 !src/views/plugins/.gitkeep
 .eslintcache
+*.swp

--- a/nodemon.json
+++ b/nodemon.json
@@ -1,0 +1,14 @@
+{
+    "verbose": true,
+    "ignore": [
+        "node_modules/*",
+        "**/*.svelte",
+        "/app/src/views/plugins/*",
+        "/plugins/*/src/frontend/views/**/*.js"
+    ],
+    "watch": [
+        "/app",
+        "/plugins",
+        "/etc/datawrapper/config.js"
+    ]
+}


### PR DESCRIPTION
I got frustrated while debugging nodemon watch/ignore patterns because it always required rebuilding the `frontend` docker container. With https://github.com/datawrapper/docker/pull/53 nodemon will instead read the config from a json file which is linked into the container, allowing changing the config while the container is running